### PR TITLE
Updated npm install to include concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@
 
 Install global dependencies:
 ```bash
-npm install -g typescript
-npm install -g angular-cli
+npm install -g typescript angular-cli concurrently
 ```
 
 ## Create a new project based on the MEAN Start


### PR DESCRIPTION
The `concurrently` package was missing from the installation instructions.