### PR TITLE
Fix for CRUD delete method not returning a response

### DIFF
--- a/server/routes/api/crud.ts
+++ b/server/routes/api/crud.ts
@@ -70,6 +70,8 @@ Object.keys(models).forEach((name) => {
       }, (err) => {
         if (err) {
           res.json({ error: err });
+        } else {
+          return res.status(204).end();
         }
       });
     });


### PR DESCRIPTION
Could return 200, but 204 seems more appropriate since its distinguished from 200.